### PR TITLE
Correct issue 2: Prevent Exception on Received Error With Null Message

### DIFF
--- a/Tftp.Net/Transfer/States/ReceivedError.cs
+++ b/Tftp.Net/Transfer/States/ReceivedError.cs
@@ -11,7 +11,22 @@ namespace Tftp.Net.Transfer.States
         private readonly TftpTransferError error;
 
         public ReceivedError(Error error)
-            : this(new TftpErrorPacket(error.ErrorCode, error.Message)) { }
+        {
+            TftpErrorPacket errorReceived;
+
+            /* Create the Error Package while handling the case where the sender */
+            /* did not provide an error message. */
+            try
+            {
+                errorReceived = new TftpErrorPacket(error.ErrorCode, error.Message);
+            }
+            catch(ArgumentException)
+            {
+                errorReceived = new TftpErrorPacket(error.ErrorCode, "No Message Provided");
+            }
+
+            this.error = errorReceived;
+        }
 
         public ReceivedError(TftpTransferError error)
         {

--- a/Tftp.Net/Transfer/States/ReceivedError.cs
+++ b/Tftp.Net/Transfer/States/ReceivedError.cs
@@ -11,21 +11,11 @@ namespace Tftp.Net.Transfer.States
         private readonly TftpTransferError error;
 
         public ReceivedError(Error error)
+            : this(new TftpErrorPacket(error.ErrorCode, GetNonEmptyErrorMessage(error))) { }
+
+        private static string GetNonEmptyErrorMessage(Error error)
         {
-            TftpErrorPacket errorReceived;
-
-            /* Create the Error Package while handling the case where the sender */
-            /* did not provide an error message. */
-            try
-            {
-                errorReceived = new TftpErrorPacket(error.ErrorCode, error.Message);
-            }
-            catch(ArgumentException)
-            {
-                errorReceived = new TftpErrorPacket(error.ErrorCode, "No Message Provided");
-            }
-
-            this.error = errorReceived;
+            return string.IsNullOrEmpty(error.Message) ? "(No error message provided)" : error.Message;
         }
 
         public ReceivedError(TftpTransferError error)


### PR DESCRIPTION
When an error message is received handle the exception generated if the sender does not provide an error string in the message. Reference issue #2 .

Reran test suite and confirmed tests passed.
Reran scenario causing the issue report and confirmed it is resolved.