### PR TITLE
Hotfix/issue 6 update

### DIFF
--- a/Tftp.Net/Transfer/States/ReceivedError.cs
+++ b/Tftp.Net/Transfer/States/ReceivedError.cs
@@ -11,7 +11,22 @@ namespace Tftp.Net.Transfer.States
         private readonly TftpTransferError error;
 
         public ReceivedError(Error error)
-            : this(new TftpErrorPacket(error.ErrorCode, error.Message)) { }
+        {
+            TftpErrorPacket errorReceived;
+
+            /* Create the Error Package while handling the case where the sender */
+            /* did not provide an error message. */
+            try
+            {
+                errorReceived = new TftpErrorPacket(error.ErrorCode, error.Message);
+            }
+            catch(ArgumentException)
+            {
+                errorReceived = new TftpErrorPacket(error.ErrorCode, "No Message Provided");
+            }
+
+            this.error = errorReceived;
+        }
 
         public ReceivedError(TftpTransferError error)
         {

--- a/Tftp.Net/Transfer/States/Receiving.cs
+++ b/Tftp.Net/Transfer/States/Receiving.cs
@@ -27,7 +27,13 @@ namespace Tftp.Net.Transfer.States
                 }
                 else
                 {
-                    nextBlockNumber++;
+                    int tempBlockNumber = (int)nextBlockNumber + 1;
+                    if (tempBlockNumber > (int)UInt16.MaxValue)
+                    {
+                        // On wrap-around of block number, restart at the first valid data block number (1).
+                        tempBlockNumber = 1;
+                    }
+                    nextBlockNumber = (ushort)tempBlockNumber;
                     bytesReceived += command.Bytes.Length;
                     Context.RaiseOnProgress(bytesReceived);
                 }

--- a/Tftp.Net/Transfer/States/Sending.cs
+++ b/Tftp.Net/Transfer/States/Sending.cs
@@ -39,7 +39,13 @@ namespace Tftp.Net.Transfer.States
             }
             else
             {
-                SendNextPacket((ushort)(lastBlockNumber + 1));
+                int nextBlockNumber = (int)lastBlockNumber + 1;
+                if (nextBlockNumber > (int)UInt16.MaxValue)
+                {
+                    // On wrap-around of block number, restart at the first valid data block number (1).
+                    nextBlockNumber = 1;
+                }
+                SendNextPacket((ushort)nextBlockNumber);
             }
         }
 


### PR DESCRIPTION
Correct transfer error on large data files when block number 65535 is exceeded. Per the TFTP spec, the lowest valid TFTP data block number is 1, instead of 0. Fixes issue #6 .  

Reran unit tests (all passed) and confirmed the issue is resolved.