### PR TITLE
Specify local interface for TFTP sockets

### DIFF
--- a/Tftp.Net/Channel/TransferChannelFactory.cs
+++ b/Tftp.Net/Channel/TransferChannelFactory.cs
@@ -17,10 +17,10 @@ namespace Tftp.Net.Channel
             throw new NotSupportedException("Unsupported endpoint type.");
         }
 
-        public static ITransferChannel CreateConnection(EndPoint remoteAddress)
+        public static ITransferChannel CreateConnection(EndPoint remoteAddress, IPEndPoint localAddress)
         {
             if (remoteAddress is IPEndPoint)
-                return CreateConnectionUdp((IPEndPoint)remoteAddress);
+                return CreateConnectionUdp((IPEndPoint)remoteAddress, localAddress);
 
             throw new NotSupportedException("Unsupported endpoint type.");
         }
@@ -33,9 +33,8 @@ namespace Tftp.Net.Channel
             return new UdpChannel(socket);
         }
 
-        private static ITransferChannel CreateConnectionUdp(IPEndPoint remoteAddress)
+        private static ITransferChannel CreateConnectionUdp(IPEndPoint remoteAddress, IPEndPoint localAddress)
         {
-            IPEndPoint localAddress = new IPEndPoint(IPAddress.Any, 0);
             UdpChannel channel = new UdpChannel(new UdpClient(localAddress));
             channel.RemoteEndpoint = remoteAddress;
             return channel;

--- a/Tftp.Net/TftpClient.cs
+++ b/Tftp.Net/TftpClient.cs
@@ -71,13 +71,33 @@ namespace Tftp.Net
         }
 
         /// <summary>
+        /// GET a file from the server via the specific local interface.
+        /// You have to call Start() on the returned ITftpTransfer to start the transfer.
+        /// </summary>
+        public ITftpTransfer Download(String filename, IPAddress localInterface)
+        {
+            ITransferChannel channel = TransferChannelFactory.CreateConnection(remoteAddress, new IPEndPoint(localInterface, 0));
+            return new RemoteReadTransfer(channel, filename);
+        }
+
+        /// <summary>
         /// GET a file from the server.
         /// You have to call Start() on the returned ITftpTransfer to start the transfer.
         /// </summary>
         public ITftpTransfer Download(String filename)
         {
-            ITransferChannel channel = TransferChannelFactory.CreateConnection(remoteAddress);
+            ITransferChannel channel = TransferChannelFactory.CreateConnection(remoteAddress, new IPEndPoint(IPAddress.Any, 0));
             return new RemoteReadTransfer(channel, filename);
+        }
+
+        /// <summary>
+        /// PUT a file from the server via the specific local interface.
+        /// You have to call Start() on the returned ITftpTransfer to start the transfer.
+        /// </summary>
+        public ITftpTransfer Upload(String filename, IPAddress localInterface)
+        {
+            ITransferChannel channel = TransferChannelFactory.CreateConnection(remoteAddress, new IPEndPoint(localInterface, 0));
+            return new RemoteWriteTransfer(channel, filename);
         }
 
         /// <summary>
@@ -86,7 +106,7 @@ namespace Tftp.Net
         /// </summary>
         public ITftpTransfer Upload(String filename)
         {
-            ITransferChannel channel = TransferChannelFactory.CreateConnection(remoteAddress);
+            ITransferChannel channel = TransferChannelFactory.CreateConnection(remoteAddress, new IPEndPoint(IPAddress.Any, 0));
             return new RemoteWriteTransfer(channel, filename);
         }
     }

--- a/Tftp.Net/TftpServer.cs
+++ b/Tftp.Net/TftpServer.cs
@@ -39,6 +39,11 @@ namespace Tftp.Net
         /// </summary>
         private readonly ITransferChannel serverSocket;
 
+        /// <summary>
+        /// Keep the address of the local interface so that UDP packets do not get lost into wrong one
+        /// </summary>
+        private readonly IPAddress localInterface;
+
         public TftpServer(IPEndPoint localAddress)
         {
             if (localAddress == null)
@@ -47,6 +52,7 @@ namespace Tftp.Net
             serverSocket = TransferChannelFactory.CreateServer(localAddress);
             serverSocket.OnCommandReceived += new TftpCommandHandler(serverSocket_OnCommandReceived);
             serverSocket.OnError += new TftpChannelErrorHandler(serverSocket_OnError);
+            localInterface = localAddress.Address;
         }
 
         public TftpServer(IPAddress localAddress)
@@ -90,7 +96,7 @@ namespace Tftp.Net
                 return;
 
             //Open a connection to the client
-            ITransferChannel channel = TransferChannelFactory.CreateConnection(endpoint);
+            ITransferChannel channel = TransferChannelFactory.CreateConnection(endpoint, new IPEndPoint(localInterface, 0));
 
             //Create a wrapper for the transfer request
             ReadOrWriteRequest request = (ReadOrWriteRequest)command;


### PR DESCRIPTION
Sometimes, UDP packets can be routed via a wrong (especially wireless) interface causing problems in TFTP protocol.
In order to prevent that, an option to specify the network interface is added.