### PR TITLE
Small Bug Fix in TftpTransferProgress

### DIFF
--- a/Tftp.Net/TftpTransferProgress.cs
+++ b/Tftp.Net/TftpTransferProgress.cs
@@ -26,7 +26,7 @@ namespace Tftp.Net
         public override string ToString()
         {
             if (TotalBytes > 0)
-                return (TransferredBytes * 100) / TotalBytes + "% completed";
+                return (TransferredBytes * 100L) / TotalBytes + "% completed";
             else
                 return TransferredBytes + " bytes transferred";
         }


### PR DESCRIPTION
Fixed a small bug where when transferring large files the ToString() method can return incorrect % complete values. This is because the TransferredBytes was being multiplied by an int with the result being a int, marking the multiplier as a long solved the issue.