### PR TITLE
No longer set missing Negotiated BlockSize and Timeout options to def…

### DIFF
--- a/Tftp.Net/Transfer/States/SendWriteRequest.cs
+++ b/Tftp.Net/Transfer/States/SendWriteRequest.cs
@@ -33,7 +33,7 @@ namespace Tftp.Net.Transfer.States
             else
             if (command is Acknowledgement && (command as Acknowledgement).BlockNumber == 0)
             {
-                Context.FinishOptionNegotiation(TransferOptionSet.NewEmptySet());
+                Context.FinishOptionNegotiation(Context.ProposedOptions);
                 BeginSendingTo(endpoint);
             }
             else


### PR DESCRIPTION
…ault

Only use Negotiated BlockSize, TransferSize & RetryTimeout if NegotiatedOptions includes them