### PR TITLE
Use proposed options if server does not support negotiated options

### DIFF
--- a/Tftp.Net/Transfer/States/SendWriteRequest.cs
+++ b/Tftp.Net/Transfer/States/SendWriteRequest.cs
@@ -33,7 +33,6 @@ namespace Tftp.Net.Transfer.States
             else
             if (command is Acknowledgement && (command as Acknowledgement).BlockNumber == 0)
             {
-                Context.FinishOptionNegotiation(Context.ProposedOptions);
                 BeginSendingTo(endpoint);
             }
             else

--- a/Tftp.Net/Transfer/States/SendWriteRequest.cs
+++ b/Tftp.Net/Transfer/States/SendWriteRequest.cs
@@ -33,7 +33,7 @@ namespace Tftp.Net.Transfer.States
             else
             if (command is Acknowledgement && (command as Acknowledgement).BlockNumber == 0)
             {
-                Context.FinishOptionNegotiation(TransferOptionSet.NewEmptySet());
+                Context.FinishOptionNegotiation(Context.ProposedOptions);
                 BeginSendingTo(endpoint);
             }
             else


### PR DESCRIPTION
If the TFTP server does not support negotiated options during uploads (e.g. server responds with ACK rather than OACK to WRQ), use the proposed options rather than "negotiated".